### PR TITLE
MB-30040: Add support for -fsanitize=thread in GCC 7.3.0

### DIFF
--- a/folly/test/MemcpyTest.cpp
+++ b/folly/test/MemcpyTest.cpp
@@ -33,7 +33,7 @@ void init() {
 } // namespace
 
 TEST(memcpy, zero_len)
-FOLLY_DISABLE_UNDEFINED_BEHAVIOR_SANITIZER("nonnull-attribute") {
+FOLLY_DISABLE_NONNULL_SANITIZER {
   // If length is 0, we shouldn't touch any memory.  So this should
   // not crash.
   char* srcNull = nullptr;


### PR DESCRIPTION
When compiling using -fsanitize=thread in GCC 7.3.0, a compilation
error occurs because GCC 7.3.0 does not support the "no_sanitize"
attribute. The current usages of the "no_sanitize" attribute when
compiling with -fsanitize=thread are "undefined" and
"nonnull-attribute". These can be replaced with the
"no_sanitize_undefined" and "nonnull" attributes respectively.

Do some feature checking to see if the appropriate attributes are
supported, and use them, or an alternative, if they are.