### PR TITLE
MB-30040: Fix no_sanitize attribute use on Clang

### DIFF
--- a/folly/CPortability.h
+++ b/folly/CPortability.h
@@ -121,33 +121,34 @@
 #endif
 
 #if FOLLY_SANITIZE
-/**
- * GCC 8.2.0 and Clang 6.0 both support the no_sanitize attribute, however,
- * GCC 7.3.0 does not. Check for alternative attributes if no_sanitize is not
- * available.
- */
-#if defined(__has_cpp_attribute)
 
-#if __has_cpp_attribute(no_sanitize)
+// Error early if we don't have __has_attribute to be more explicit
+#ifndef __has_attribute
+#error Need __has_attribute to determine which attributes can be used
+#endif
+
+// Find an attribute to disable undefined behaviour sanitization
+#if __has_attribute(__no_sanitize__)
 #define FOLLY_DISABLE_UNDEFINED_BEHAVIOR_SANITIZER \
-  __attribute__((no_sanitize("undefined")))
-#elif __has_cpp_attribute(no_sanitize_undefined)
+  __attribute__((__no_sanitize__("undefined")))
+#elif __has_attribute(__no_sanitize_undefined__)
 #define FOLLY_DISABLE_UNDEFINED_BEHAVIOR_SANITIZER \
-  __attribute__((no_sanitize_undefined))
-#endif // __has_cpp_attribute(no_sanitize)
+  __attribute__((__no_sanitize_undefined__))
+#else // __has_attribute(no_sanitize)
+#error No attribute to disable undefined behaviour sanitization
+#endif // __has_attribute(no_sanitize)
 
-#if __has_cpp_attribute(no_sanitize)
+// Find an attribute to disable non-null sanitization
+#if __has_attribute(__no_sanitize__)
 #define FOLLY_DISABLE_NONNULL_SANITIZER \
-  __attribute__((no_sanitize("nonnull-attribute")))
-#elif __has_cpp_attribute(nonnull)
+  __attribute__((__no_sanitize__("nonnull-attribute")))
+#elif __has_attribute(__nonnull__)
 #define FOLLY_DISABLE_NONNULL_SANITIZER \
-  __attribute__((nonnull))
-#endif // __has_cpp_attribute(no_sanitize)
+  __attribute__((__nonnull__))
+#else // has_attribute(no_sanitize)
+#error No attribute to disable non-null sanitization
+#endif // __has_attribute(no_sanitize)
 
-#else // defined(__has_cpp_attribute)
-#error __has_cpp_attribute was not found, cannot determine which attributes to\
-       use.
-#endif // defined(__has_cpp_attribute)
 #else // FOLLY_SANITIZE
 #define FOLLY_DISABLE_UNDEFINED_BEHAVIOR_SANITIZER
 #define FOLLY_DISABLE_NONNULL_SANITIZER


### PR DESCRIPTION
Fix an issue introduced in commit da2dd53e5a54231e90e0fedefcd7f22f7725aaec where we looked for the wrong attribute when compiling with clang.