### PR TITLE
MB-44253: Remove try/catch from ThreadPoolExecutor::runTask

### DIFF
--- a/folly/executors/ThreadPoolExecutor.cpp
+++ b/folly/executors/ThreadPoolExecutor.cpp
@@ -94,15 +94,7 @@ void ThreadPoolExecutor::runTask(const ThreadPtr& thread, Task&& task) {
     }
   } else {
     folly::RequestContextScopeGuard rctx(task.context_);
-    try {
-      task.func_();
-    } catch (const std::exception& e) {
-      LOG(ERROR) << "ThreadPoolExecutor: func threw unhandled "
-                 << typeid(e).name() << " exception: " << e.what();
-    } catch (...) {
-      LOG(ERROR) << "ThreadPoolExecutor: func threw unhandled non-exception "
-                    "object";
-    }
+    task.func_();
     stats.runTime = std::chrono::steady_clock::now() - startTime;
   }
 


### PR DESCRIPTION
This try/catch block prevents unhandled exceptions in GlobalTasks from
triggering std::terminate, and in turn generating a Breakpad minidump
with the state of the process when the exception was thrown (as
opposed to where it was caught).

Started a discussion with Folly about a more generic way to address
this (i.e. making the try/catch somehow optional) - see
https://github.com/facebook/folly/issues/1525 - but in the short-term
simply removing the code from our branch.