### PR TITLE
[WIN32] Allow for setting SO_REUSEADDR on win32

### DIFF
--- a/folly/io/async/AsyncServerSocket.cpp
+++ b/folly/io/async/AsyncServerSocket.cpp
@@ -829,7 +829,8 @@ void AsyncServerSocket::setupSocket(NetworkSocket fd, int family) {
 
   // Set reuseaddr to avoid 2MSL delay on server restart
   int one = 1;
-  if (netops::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) !=
+  if (reuseAddrEnabled_ &&
+      netops::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) !=
       0) {
     auto errnoCopy = errno;
     // This isn't a fatal error; just log an error message and continue

--- a/folly/io/async/AsyncUDPSocket.cpp
+++ b/folly/io/async/AsyncUDPSocket.cpp
@@ -30,12 +30,6 @@
 #include <folly/portability/Unistd.h>
 #include <folly/small_vector.h>
 
-// Due to the way kernel headers are included, this may or may not be defined.
-// Number pulled from 3.10 kernel headers.
-#ifndef SO_REUSEPORT
-#define SO_REUSEPORT 15
-#endif
-
 #if FOLLY_HAVE_VLA
 #define FOLLY_HAVE_VLA_01 1
 #else

--- a/folly/net/NetOps.cpp
+++ b/folly/net/NetOps.cpp
@@ -506,11 +506,7 @@ int setsockopt(
     const void* optval,
     socklen_t optlen) {
 #ifdef _WIN32
-  if (optname == SO_REUSEADDR) {
-    // We don't have an equivelent to the Linux & OSX meaning of this
-    // on Windows, so ignore it.
-    return 0;
-  } else if (optname == SO_REUSEPORT) {
+  if (optname == SO_REUSEPORT) {
     // Windows's SO_REUSEADDR option is closer to SO_REUSEPORT than
     // it is to the Linux & OSX meaning of SO_REUSEADDR.
     return -1;


### PR DESCRIPTION
And make it possible for the AsyncServerSocket to _not_ enable
SO_REUSEADDR (which may be used in unit tests).

It feels _wrong_ to silently ignore calling SO_REUSEADDR
on Win32 as it does change the behavior on a socket which
the calling application may need.