### PR TITLE
MB-44253: Remove try/catch from Executor*::runTask methods

### DIFF
--- a/CMake/folly-deps.cmake
+++ b/CMake/folly-deps.cmake
@@ -324,3 +324,7 @@ target_link_libraries(folly_deps INTERFACE
   ${FOLLY_SHINY_DEPENDENCIES}
   ${FOLLY_ASAN_FLAGS}
 )
+
+if (WIN32)
+    target_link_libraries(folly_deps INTERFACE Shlwapi.lib)
+endif()


### PR DESCRIPTION
Slightly adapted Dave Rigby's patch:

commit 3d4519d9771d55a05c65830cfd0c95cc1994d211
Author: Dave Rigby <daver@couchbase.com>
Date:   Thu Feb 11 14:01:47 2021 +0000

    MB-44253: Remove try/catch from Executor*::runTask methods

    These try/catch blocks prevent unhandled exceptions in GlobalTasks
    from triggering std::terminate, and in turn generating a Breakpad
    minidump with the state of the process when the exception was thrown
    (as opposed to where it was caught).

    Started a discussion with Folly about a more generic way to address
    this (i.e. making the try/catch somehow optional) - see
    https://github.com/facebook/folly/issues/1525 - but in the short-term
    simply remove the invokeCatchingExns() wrapper from our branch.

    (Note: Currently we only use ThreadPoolExecutor and hence we only
    /need/ to change that one, but for consistency / possible future use
    change all instances).